### PR TITLE
Add selectable shapes

### DIFF
--- a/documentation/src/components/Sidebar.astro
+++ b/documentation/src/components/Sidebar.astro
@@ -25,4 +25,5 @@ import NavItem from './NavItem.astro';
   <div class="px-6 py-2 mt-2 text-sm font-bold text-gray-700">Examples</div>
   <NavItem text="Network Diagram" href="/examples/network-diagram" icon="example" />
   <NavItem text="Neural Network" href="/examples/neural-network" icon="example" />
+  <NavItem text="Selection" href="/examples/selection" icon="example" />
 </nav>

--- a/documentation/src/diagrams/SelectionExample.tsx
+++ b/documentation/src/diagrams/SelectionExample.tsx
@@ -1,0 +1,47 @@
+/** @jsxImportSource cx */
+import { Cell, Diagram, Flow, Shape } from "cx-diagrams";
+import { Svg } from "cx/svg";
+import { KeySelection, bind, tpl } from "cx/ui";
+import { Repeater } from "cx/widgets";
+
+const shapes = [
+  { id: "a", text: "A", shape: "rectangle" },
+  { id: "b", text: "B", shape: "rectangle" },
+  { id: "c", text: "C", shape: "circle" },
+  { id: "d", text: "D", shape: "rhombus" },
+];
+
+export default () => (
+  <cx>
+    <div class="w-full">
+      <div
+        class="px-3 py-2 text-sm text-gray-600 border-t bg-gray-50"
+        text={tpl("Selected: {selection:s}")}
+      />
+      <Svg class="w-full h-full min-h-[360px] min-w-[600px] bg-white border-t border-b">
+        <Diagram center showGrid>
+          <Flow direction="right" gap={2}>
+            <Repeater records={shapes} recordAlias="$shape">
+              <Cell width={3} height={2}>
+                <Shape
+                  id={bind("$shape.id")}
+                  text={bind("$shape.text")}
+                  shape={bind("$shape.shape")}
+                  stroke="gray"
+                  fill="white"
+                  selection={{
+                    type: KeySelection,
+                    bind: "selection",
+                    keyField: "id",
+                    multiple: true,
+                    record: { bind: "$shape" },
+                  }}
+                />
+              </Cell>
+            </Repeater>
+          </Flow>
+        </Diagram>
+      </Svg>
+    </div>
+  </cx>
+);

--- a/documentation/src/pages/examples/selection.mdx
+++ b/documentation/src/pages/examples/selection.mdx
@@ -1,0 +1,57 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: Selection
+---
+
+import Split from "../../components/Split.astro";
+import Prose from "../../components/Prose.astro";
+import CodeSnippet from "../../components/CodeSnippet.astro";
+import SelectionExample from "../../diagrams/SelectionExample.tsx";
+
+export const code = `<Diagram center showGrid>
+    <Flow direction="right" gap={2}>
+        <Repeater records={shapes} recordAlias="$shape">
+            <Cell width={3} height={2}>
+                <Shape
+                    id={bind("$shape.id")}
+                    text={bind("$shape.text")}
+                    shape={bind("$shape.shape")}
+                    stroke="gray"
+                    fill="white"
+                    selection={{
+                        type: KeySelection,
+                        bind: "selection",
+                        keyField: "id",
+                        multiple: true,
+                        record: { bind: "$shape" },
+                    }}
+                />
+            </Cell>
+        </Repeater>
+    </Flow>
+</Diagram>`;
+
+<Split>
+  <Prose>
+    # Selection
+
+    Selection lives on the `Shape` via its `selection` property, following the
+    same model as CxJS widgets such as `Grid`, `List` and `Marker`. Provide a
+    `record` binding so the selection can identify each shape; a `KeySelection`
+    keyed by `id` is the usual choice. Shapes that bind to the same selection
+    path share a single selection.
+
+    - **Click** a shape to select it.
+    - **Ctrl+Click** to toggle a shape in and out of the selection.
+    - **Shift+Click** to extend the selection (when `multiple` is set).
+
+    The selected keys are written to the store at the bound path
+    (`selection` in this example).
+
+  </Prose>
+</Split>
+
+<Split>
+  <CodeSnippet code={code} class="max-h-[500px]" />
+  <SelectionExample client:load slot="right" />
+</Split>

--- a/packages/cx-diagrams/src/Diagram.tsx
+++ b/packages/cx-diagrams/src/Diagram.tsx
@@ -234,11 +234,16 @@ class DiagramComponent extends VDOM.Component<
   };
 
   UNSAFE_componentWillReceiveProps(props: DiagramComponentProps) {
-    this.setState({
-      zoom: props.data.zoom,
-      offsetX: props.data.offsetX,
-      offsetY: props.data.offsetY,
-    });
+    // Only adopt zoom/pan from the store when the bound value actually changed
+    // externally. Re-renders triggered by unrelated store changes (e.g. shape
+    // selection) must not reset the user's current pan/zoom.
+    let prev = this.props.data;
+    let next = props.data;
+    let newState: Partial<DiagramComponentState> = {};
+    if (next.zoom !== prev.zoom) newState.zoom = next.zoom;
+    if (next.offsetX !== prev.offsetX) newState.offsetX = next.offsetX;
+    if (next.offsetY !== prev.offsetY) newState.offsetY = next.offsetY;
+    if (Object.keys(newState).length > 0) this.setState(newState as DiagramComponentState);
   }
 
   render() {

--- a/packages/cx-diagrams/src/Shape.scss
+++ b/packages/cx-diagrams/src/Shape.scss
@@ -1,3 +1,6 @@
+// Extra stroke width applied to a selected shape. Override to theme selection.
+$cx-diagram-shape-selected-stroke-width: 2px !default;
+
 .cxb-shape {
    cursor: pointer;
    stroke-width: 1;
@@ -16,4 +19,10 @@
 
 .cxb-shape.cxs-dragged {
    opacity: 0.5;
+}
+
+// Mirrors how CxJS charts (Bar/Column/Pie) indicate selection: thicken the
+// stroke via a variable and keep the shape's own colors. No hard-coded color.
+.cxb-shape.cxs-selected .cxe-shape-shape {
+   stroke-width: $cx-diagram-shape-selected-stroke-width;
 }

--- a/packages/cx-diagrams/src/Shape.tsx
+++ b/packages/cx-diagrams/src/Shape.tsx
@@ -8,6 +8,7 @@ import {
   NumberProp,
   Prop,
   RenderingContext,
+  Selection,
   StringProp,
   StructuredProp,
   StyleProp,
@@ -119,6 +120,15 @@ export interface ShapeConfig extends BoundedObjectConfig {
 
   /** Custom drag clone configuration. If not set, a clone of the shape is used. */
   clone?: DragCloneConfig;
+
+  /**
+   * Selection configuration. When set, the shape becomes selectable and its
+   * selected state is reflected through the `selected` CSS state. Provide the
+   * `record` (and optionally `index`) bindings so the selection can identify
+   * this shape, e.g.
+   * `{ type: KeySelection, bind: "selection", keyField: "id", record: { bind: "$record" } }`.
+   */
+  selection?: any;
 }
 
 interface ShapeData {
@@ -142,6 +152,8 @@ interface ShapeData {
   farShapeStyle?: any;
   cloneClass?: string;
   cloneStyle?: any;
+  selected?: boolean;
+  stateMods?: Record<string, any>;
 }
 
 export interface ShapeInstance extends Instance<Shape>, TooltipParentInstance {
@@ -171,6 +183,7 @@ export class Shape extends BoundedObject<ShapeConfig> {
   declare onDrop?: string | ((e: DragEvent, instance: Instance) => any);
   declare onDropTest?: string | ((e: DragEvent, instance: Instance) => boolean);
   declare clone?: DragCloneConfig;
+  declare selection: Selection;
 
   el: SVGElement | null = null;
 
@@ -184,11 +197,13 @@ export class Shape extends BoundedObject<ShapeConfig> {
       this.cloneStyle = parseStyle(this.clone.style);
       this.cloneClass = this.clone.class;
     }
+    this.selection = Selection.create(this.selection);
     super.init();
   }
 
   declareData(...args: any[]) {
-    super.declareData(...args, {
+    let selection = this.selection.configureWidget(this);
+    super.declareData(...args, selection, {
       id: undefined,
       text: undefined,
       shape: undefined,
@@ -206,6 +221,25 @@ export class Shape extends BoundedObject<ShapeConfig> {
       farShapeStyle: { structured: true },
       cloneClass: { structured: true },
       cloneStyle: { structured: true },
+    });
+  }
+
+  prepareData(context: RenderingContext, instance: ShapeInstance) {
+    let { data } = instance;
+    data.selected = this.selection.isInstanceSelected(instance);
+    data.stateMods = {
+      ...data.stateMods,
+      selected: data.selected,
+      selectable: !this.selection.isDummy,
+    };
+    super.prepareData(context, instance);
+  }
+
+  select(e: React.MouseEvent, instance: ShapeInstance) {
+    if (this.selection.isDummy) return;
+    this.selection.selectInstance(instance, {
+      toggle: e.ctrlKey && !e.shiftKey,
+      add: (e.ctrlKey && e.shiftKey) || (this.selection.multiple && e.shiftKey),
     });
   }
 
@@ -378,8 +412,8 @@ class ShapeComponent extends VDOM.Component<
         onMouseUp={ddMouseUp}
         onMouseLeave={this.onMouseLeave}
         onClick={
-          widget.onClick
-            ? (e: React.MouseEvent) => instance.invoke("onClick", e, instance)
+          !widget.selection.isDummy || widget.onClick
+            ? this.onClick
             : undefined
         }
         onDoubleClick={
@@ -401,6 +435,13 @@ class ShapeComponent extends VDOM.Component<
       </g>
     );
   }
+
+  onClick = (e: React.MouseEvent) => {
+    let { instance } = this.props;
+    let { widget } = instance;
+    if (!widget.selection.isDummy) widget.select(e, instance);
+    if (widget.onClick) instance.invoke("onClick", e, instance);
+  };
 
   onMouseDown = (e: React.MouseEvent) => {
     let { instance } = this.props;


### PR DESCRIPTION
Selection now lives on the Shape widget, following the CxJS Marker/Grid
model:

- `Shape` gains a `selection` prop; it creates the Selection instance,
  wires `configureWidget`/`isInstanceSelected`, reflects state through the
  `selected`/`selectable` CSS states, and calls `selectInstance` on click.
- Multiple selection via a `multiple` KeySelection: Ctrl+click toggles,
  Shift+click extends (options passed to `selectInstance`, like ColumnBar).
- Selected styling mirrors CxJS charts: an overridable
  `$cx-diagram-shape-selected-stroke-width` variable, no hard-coded color.
- **Fix Diagram pan/zoom being reset by unrelated re-renders (e.g. selection):
  only adopt zoom/offset from the store when the bound value changed.**
- Docs: add a Selection example page and sidebar entry.